### PR TITLE
(feat) Local docker spawner -> basic ECS (Fargate) spawner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ ENV DOCKER_VER=18.03.1
 RUN pip install oauthenticator dockerspawner psycopg2-binary
 RUN wget -q -O - "https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VER}-ce.tgz" | tar -xzvf - -C /usr/bin --strip-components=1
 
+COPY config/ecs_spawner.py /opt/conda/lib/python3.6/site-packages/ecs_spawner.py
+
 COPY config/jupyterhub_config.py /usr/local/etc/jupyter/jupyterhub_config.py
 COPY config/jupyter_notebook_config.py /usr/local/etc/jupyter/jupyter_notebook_config.py
 COPY config/spawner-init.sh /usr/local/etc/jupyter/spawner-init.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG JUPYTERHUB_VER=1.0.dev
+ARG JUPYTERHUB_VER=0.9.2
 FROM jupyterhub/jupyterhub:$JUPYTERHUB_VER
 
 RUN apt update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG JUPYTERHUB_VER=1.0
+ARG JUPYTERHUB_VER=1.0.dev
 FROM jupyterhub/jupyterhub:$JUPYTERHUB_VER
 
 RUN apt update && \

--- a/Dockerfile-singleuser
+++ b/Dockerfile-singleuser
@@ -1,4 +1,4 @@
-ARG VER=1.0.0.dev
+ARG VER=0.9.2
 FROM jupyterhub/singleuser:$VER
 
 USER root

--- a/Dockerfile-singleuser
+++ b/Dockerfile-singleuser
@@ -43,5 +43,7 @@ RUN conda install --quiet --yes \
     conda clean -tipsy && \
     fix-permissions $CONDA_DIR
 
+COPY config/ecs_spawner.py /opt/conda/lib/python3.6/site-packages/ecs_spawner.py
+
 # Switch back to jovyan to avoid accidental container runs as root
 USER $NB_UID

--- a/config/ecs_spawner.py
+++ b/config/ecs_spawner.py
@@ -78,6 +78,7 @@ class EcsSpawner(Spawner):
                 self.calling_run_task = True
                 run_response = await _run_task(self.log, self.endpoint)
                 self.task_arn = run_response['tasks'][0]['taskArn']
+                self.log.debug("Set task arn to (%s)", self.task_arn)
             finally:
                 self.calling_run_task = False
 
@@ -95,6 +96,8 @@ class EcsSpawner(Spawner):
                 if status == 'RUNNING':
                     self.task_ip = ip
                     self.task_port = port
+                    self.log.debug("Set task ip to (%s)", self.task_ip)
+                    self.log.debug("Set task port to (%s)", self.task_port)
                     break
 
                 await gen.sleep(1)

--- a/config/ecs_spawner.py
+++ b/config/ecs_spawner.py
@@ -1,0 +1,252 @@
+import datetime
+import hashlib
+import hmac
+import json
+import os
+import urllib
+
+from jupyterhub.spawner import (
+    Spawner,
+)
+from tornado import (
+    gen,
+)
+from tornado.httpclient import (
+    AsyncHTTPClient,
+    HTTPError,
+    HTTPRequest,
+)
+from traitlets import (
+    Bool,
+    Dict,
+    Int,
+    Unicode,
+)
+
+
+class EcsSpawner(Spawner):
+    # We mostly are able to call the AWS API to determine status. However, when we yield the
+    # event loop to create the task, if there is a poll before the creation is complete,
+    # we must behave as though we are running/starting, but we have no IDs to use with which
+    # to check the task.
+    calling_run_task = False
+
+    endpoint = Dict(config=True)
+    task_arn = Unicode('')
+    task_ip = Unicode('')
+    task_port = Int(0)
+
+    def load_state(self, state):
+        ''' Misleading name: this "loads" the state onto self, to be used by other methods '''
+
+        super().load_state(state)
+
+        # Called when first created: we might have no state from a previous invocation
+        self.task_arn = state.get('task_arn', '')
+        self.container_instance_arn = state.get('container_instance_arn', '')
+
+    def get_state(self):
+        ''' Misleading name: the return value of get_state is saved to the database in order
+        to be able to restore after the hub went down '''
+
+        state = super().get_state()
+        state['task_arn'] = self.task_arn
+        state['task_ip'] = self.task_ip
+        state['task_port'] = self.task_port
+
+        return state
+
+    async def poll(self):
+        # Return values, as dictacted by the Jupyterhub framework:
+        # 0                   == not running, or not starting up, i.e. we need to call start
+        # None                == running, or not finished starting
+        # 1, or anything else == error
+
+        return \
+            None if self.calling_run_task else \
+            0 if (self.task_arn == '' or self.task_ip == '' or self.task_port == 0) else \
+            None if (await _get_task_status_ip_port(self.log, self.endpoint, self.task_arn))[0] in ALLOWED_STATUSES else \
+            1
+
+    async def start(self):
+        # Not entirely sure what happens if the hub goes down half way though a startup:
+        # will the details of the task be saved / restored from the database?
+        # This is coded up to be able to deal with both "yes" and "no"
+
+        if self.task_arn == '':
+            try:
+                self.calling_run_task = True
+                run_response = await _run_task(self.log, self.endpoint)
+                self.task_arn = run_response['tasks'][0]['taskArn']
+            finally:
+                self.calling_run_task = False
+
+        if self.task_ip == '' or self.task_port == 0:
+            i = 0
+            while True:
+                i += 1
+                if i >= 600:
+                    raise Exception('Task %s took too long to become RUNNING'.format(self.task_arn))
+
+                status, ip, port = await _get_task_status_ip_port(self.log, self.endpoint, self.task_arn)
+                if status not in ALLOWED_STATUSES:
+                    raise Exception('Task %s is %s'.format(self.task_arn, status))
+
+                if status == 'RUNNING':
+                    self.task_ip = ip
+                    self.task_port = port
+                    break
+
+                await gen.sleep(1)
+
+        return (self.task_ip, self.task_port)
+
+    async def stop(self, now=False):
+        if self.task_arn == '':
+            return
+
+        self.log.debug('Stopping task (%s)...', self.task_arn)
+        await _stop_task(self.log, self.endpoint, self.task_arn)
+        self.log.debug('Stopped task (%s)... (done)', self.task_arn)
+
+    def clear_state(self):
+        super().clear_state()
+        self.task_arn = ''
+        self.task_ip = ''
+        self.task_port = 0
+
+
+ALLOWED_STATUSES = ('PROVISIONING', 'PENDING', 'RUNNING')
+
+
+async def _stop_task(logger, endpoint, task_arn):
+    return await _make_ecs_request(logger, endpoint, 'StopTask', {
+        'cluster': endpoint['cluster_name'],
+        'task': task_arn
+    })
+
+
+async def _get_task_status_ip_port(logger, endpoint, task_arn):
+    described_tasks = await _describe_tasks(logger, endpoint, [task_arn])
+    task = described_tasks['tasks'][0]
+    status = task['lastStatus']
+    ip_address_attachements = [
+        attachment['value']
+        for attachment in task['attachments'][0]['details']
+        if attachment['name'] == 'privateIPv4Address'
+    ]
+    ip_address = ip_address_attachements[0] if ip_address_attachements else ''
+    port = endpoint['port']
+    return status, ip_address, port
+
+
+async def _describe_tasks(logger, endpoint, task_arns):
+    return await _make_ecs_request(logger, endpoint, 'DescribeTasks', {
+        'cluster': endpoint['cluster_name'],
+        'tasks': task_arns
+    })
+
+
+async def _run_task(logger, endpoint):
+    return await _make_ecs_request(logger, endpoint, 'RunTask', {
+        'cluster': endpoint['cluster_name'],
+        'taskDefinition': endpoint['task_definition_arn'],
+        'count': 1,
+        'launchType': 'FARGATE',
+        'networkConfiguration': {
+            'awsvpcConfiguration': {
+                'assignPublicIp': 'ENABLED',
+                'securityGroups': ['sg-00062fd201d4e674b'],
+                'subnets': ['subnet-fde8d88a'],
+            }
+        }
+    })
+
+
+async def _stop_task(logger, endpoint, task_arn):
+    return await _make_ecs_request(logger, endpoint, 'RunTask', {
+        'cluster': endpoint['cluster_name'],
+        'task': task_arn,
+    })
+
+
+async def _make_ecs_request(logger, endpoint, target, dict_data):
+    service = 'ecs'
+    body = json.dumps(dict_data).encode('utf-8')
+    headers = {
+        'X-Amz-Target': f'AmazonEC2ContainerServiceV20141113.{target}',
+        'Content-Type': 'application/x-amz-json-1.1',
+    }
+    path = '/'
+    auth_headers = _aws_auth_headers(service, endpoint, 'POST', path, {}, headers, body)
+    client = AsyncHTTPClient()
+    url = f'https://{endpoint["host"]}{path}'
+    request = HTTPRequest(url, method='POST', headers={**headers, **auth_headers}, body=body)
+    logger.debug('Making request (%s)', body)
+    try:
+        response = await client.fetch(request)
+    except HTTPError as exception:
+        logger.exception('HTTPError from ECS (%s)', exception.response.body)
+        raise
+    logger.debug('Request response (%s)', response.body)
+    return json.loads(response.body)
+
+
+def _aws_auth_headers(service, endpoint, method, path, query, headers, payload):
+    algorithm = 'AWS4-HMAC-SHA256'
+
+    now = datetime.datetime.utcnow()
+    amzdate = now.strftime('%Y%m%dT%H%M%SZ')
+    datestamp = now.strftime('%Y%m%d')
+    credential_scope = f'{datestamp}/{endpoint["region"]}/{service}/aws4_request'
+    headers_lower = {
+        header_key.lower().strip(): header_value.strip()
+        for header_key, header_value in headers.items()
+    }
+    signed_header_keys = sorted([header_key
+                                 for header_key in headers_lower.keys()] + ['host', 'x-amz-date'])
+    signed_headers = ';'.join([header_key for header_key in signed_header_keys])
+
+    def signature():
+        def canonical_request():
+            header_values = {
+                **headers_lower,
+                'host': endpoint['host'],
+                'x-amz-date': amzdate,
+            }
+
+            canonical_uri = urllib.parse.quote(path, safe='/~')
+            query_keys = sorted(query.keys())
+            canonical_querystring = '&'.join([
+                urllib.parse.quote(key, safe='~') + '=' + urllib.parse.quote(query[key], safe='~')
+                for key in query_keys
+            ])
+            canonical_headers = ''.join([
+                header_key + ':' + header_values[header_key] + '\n'
+                for header_key in signed_header_keys
+            ])
+            payload_hash = hashlib.sha256(payload).hexdigest()
+
+            return f'{method}\n{canonical_uri}\n{canonical_querystring}\n' + \
+                   f'{canonical_headers}\n{signed_headers}\n{payload_hash}'
+
+        def sign(key, msg):
+            return hmac.new(key, msg.encode('utf-8'), hashlib.sha256).digest()
+
+        string_to_sign = \
+            f'{algorithm}\n{amzdate}\n{credential_scope}\n' + \
+            hashlib.sha256(canonical_request().encode('utf-8')).hexdigest()
+
+        date_key = sign(('AWS4' + endpoint['secret_access_key']).encode('utf-8'), datestamp)
+        region_key = sign(date_key, endpoint['region'])
+        service_key = sign(region_key, service)
+        request_key = sign(service_key, 'aws4_request')
+        return sign(request_key, string_to_sign).hex()
+
+    return {
+        'x-amz-date': amzdate,
+        'Authorization': (
+            f'{algorithm} Credential={endpoint["access_key_id"]}/{credential_scope}, ' +
+            f'SignedHeaders={signed_headers}, Signature=' + signature()
+        ),
+    }

--- a/config/jupyterhub_config.py
+++ b/config/jupyterhub_config.py
@@ -1,6 +1,12 @@
 import os
-import socket
-from oauthenticator.generic import GenericOAuthenticator
+
+from oauthenticator.generic import (
+    GenericOAuthenticator,
+)
+from ecs_spawner import (
+    EcsSpawner,
+)
+
 c.JupyterHub.authenticator_class = GenericOAuthenticator
 
 c.JupyterHub.db_url = os.environ.get('DB_URL', 'sqlite:///jupyterhub.sqlite')
@@ -11,9 +17,18 @@ c.Authenticator.auto_login = True
 c.Authenticator.enable_auth_state = True
 c.Authenticator.admin_users = set([os.environ['ADMIN_USERS']])
 
-c.JupyterHub.spawner_class = 'dockerspawner.DockerSpawner'
-c.DockerSpawner.image = os.environ['DOCKER_SPAWNER_IMAGE']
-c.DockerSpawner.volumes = {'/etc/jupyter':'/etc/jupyter'}
-c.DockerSpawner.remove_containers = True
-c.DockerSpawner.debug = True
+c.JupyterHub.spawner_class = EcsSpawner
+c.EcsSpawner.endpoint = {
+    'cluster_name': os.environ['ECS_SPAWNER__CUSTER_NAME'],
+    'task_definition_arn': os.environ['ECS_SPAWNER__TASK_DEFINITION_ARN'],
+    'securityGroup': os.environ['ECS_SPAWNER__SECURITY_GROUP'],
+    'subnet': os.environ['ECS_SPAWNER__SUBNET'],
+    'region': os.environ['ECS_SPAWNER__REGION'],
+    'host': os.environ['ECS_SPAWNER__HOST'],
+    'access_key_id': os.environ['ECS_SPAWNER__ACCESS_KEY_ID'],
+    'secret_access_key': os.environ['ECS_SPAWNER__SECRET_ACCESS_KEY'],
+    'port': 8888,
+}
+c.EcsSpawner.debug = True
+c.EcsSpawner.start_timeout = 600
 c.Spawner.env_keep = ['PATH', 'DATABASE_URL']

--- a/config/jupyterhub_config.py
+++ b/config/jupyterhub_config.py
@@ -10,8 +10,6 @@ from ecs_spawner import (
 c.JupyterHub.authenticator_class = GenericOAuthenticator
 
 c.JupyterHub.db_url = os.environ.get('DB_URL', 'sqlite:///jupyterhub.sqlite')
-c.JupyterHub.ssl_cert = '/etc/jupyter/ssl.crt'
-c.JupyterHub.ssl_key = '/etc/jupyter/ssl.key'
 
 c.Authenticator.auto_login = True
 c.Authenticator.enable_auth_state = True

--- a/config/jupyterhub_config.py
+++ b/config/jupyterhub_config.py
@@ -10,6 +10,7 @@ from ecs_spawner import (
 c.JupyterHub.authenticator_class = GenericOAuthenticator
 
 c.JupyterHub.db_url = os.environ.get('DB_URL', 'sqlite:///jupyterhub.sqlite')
+c.JupyterHub.log_level = 'DEBUG'
 
 c.Authenticator.auto_login = True
 c.Authenticator.enable_auth_state = True

--- a/config/jupyterhub_config.py
+++ b/config/jupyterhub_config.py
@@ -7,7 +7,16 @@ from ecs_spawner import (
     EcsSpawner,
 )
 
-c.JupyterHub.authenticator_class = GenericOAuthenticator
+class AuthenticatorRemovedAtSymbol(GenericOAuthenticator):
+    # It looks like the @ symbol in usernames causes lots of strange issues
+    # with the notebooks
+    async def authenticate(self, handler, data=None):
+        auth = await super().authenticate(handler, data)
+        return {
+            **auth,
+            'name': auth['name'].replace('@', '.'),
+        }
+c.JupyterHub.authenticator_class = AuthenticatorRemovedAtSymbol
 
 c.JupyterHub.db_url = os.environ.get('DB_URL', 'sqlite:///jupyterhub.sqlite')
 c.JupyterHub.log_level = 'DEBUG'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,4 +8,4 @@ sed -i -e "s%__JPYNB_S3_BUCKET_NAME__%${JPYNB_S3_BUCKET_NAME}%g" /usr/local/etc/
 
 rsync -auzv /usr/local/etc/jupyter/ /etc/jupyter/
 
-jupyterhub --config=/etc/jupyter/jupyterhub_config.py --JupyterHub.bind_url="http://$(curl -Lfs http://169.254.169.254/latest/meta-data/local-ipv4):8000" --JupyterHub.hub_ip="$(curl -Lfs http://169.254.169.254/latest/meta-data/local-ipv4)"
+jupyterhub --config=/etc/jupyter/jupyterhub_config.py --JupyterHub.hub_ip="$(curl -Lfs http://169.254.169.254/latest/meta-data/local-ipv4)"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,4 +8,6 @@ sed -i -e "s%__JPYNB_S3_BUCKET_NAME__%${JPYNB_S3_BUCKET_NAME}%g" /usr/local/etc/
 
 rsync -auzv /usr/local/etc/jupyter/ /etc/jupyter/
 
-jupyterhub --config=/etc/jupyter/jupyterhub_config.py --JupyterHub.hub_ip="$(curl -Lfs http://169.254.169.254/latest/meta-data/local-ipv4)"
+# hub_ip is the interface that the hub listens on, 0.0.0.0 == all
+# hub_connect_ip is the IP that _other_ services will connect to the hub on, i.e. the current private IP address
+jupyterhub --config=/etc/jupyter/jupyterhub_config.py --JupyterHub.hub_ip="0.0.0.0" --JupyterHub.hub_connect_ip="$(curl -Lfs http://169.254.169.254/latest/meta-data/local-ipv4)"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,5 +16,4 @@ sed -i -e "s%__JPYNB_S3_BUCKET_NAME__%${JPYNB_S3_BUCKET_NAME}%g" /usr/local/etc/
 
 rsync -auzv /usr/local/etc/jupyter/ /etc/jupyter/
 
-docker pull $DOCKER_SPAWNER_IMAGE
 jupyterhub --config=/etc/jupyter/jupyterhub_config.py --JupyterHub.bind_url="https://$(curl -Lfs http://169.254.169.254/latest/meta-data/local-ipv4):8000" --JupyterHub.hub_ip="$(curl -Lfs http://169.254.169.254/latest/meta-data/local-ipv4)"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,14 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-cat <<EOF > /usr/local/etc/jupyter/ssl.key
-$SSL_KEY
-EOF
-
-cat <<EOF > /usr/local/etc/jupyter/ssl.crt
-$SSL_CERT
-EOF
-
 sed -i -e "s%__JPYNB_S3_ACCESS_KEY_ID__%${JPYNB_S3_ACCESS_KEY_ID}%g" /usr/local/etc/jupyter/jupyter_notebook_config.py
 sed -i -e "s%__JPYNB_S3_SECRET_ACCESS_KEY__%${JPYNB_S3_SECRET_ACCESS_KEY}%g" /usr/local/etc/jupyter/jupyter_notebook_config.py
 sed -i -e "s%__JPYNB_S3_REGION_NAME__%${JPYNB_S3_REGION_NAME}%g" /usr/local/etc/jupyter/jupyter_notebook_config.py
@@ -16,4 +8,4 @@ sed -i -e "s%__JPYNB_S3_BUCKET_NAME__%${JPYNB_S3_BUCKET_NAME}%g" /usr/local/etc/
 
 rsync -auzv /usr/local/etc/jupyter/ /etc/jupyter/
 
-jupyterhub --config=/etc/jupyter/jupyterhub_config.py --JupyterHub.bind_url="https://$(curl -Lfs http://169.254.169.254/latest/meta-data/local-ipv4):8000" --JupyterHub.hub_ip="$(curl -Lfs http://169.254.169.254/latest/meta-data/local-ipv4)"
+jupyterhub --config=/etc/jupyter/jupyterhub_config.py --JupyterHub.bind_url="http://$(curl -Lfs http://169.254.169.254/latest/meta-data/local-ipv4):8000" --JupyterHub.hub_ip="$(curl -Lfs http://169.254.169.254/latest/meta-data/local-ipv4)"


### PR DESCRIPTION
This is very much an early version.

  - Fargate is chosen since the aim is to be able to have an IP address per
    spawned instance. If it were ECS, we would be limited by the fact that each
    instance has a limited number if network interfaces.

  - We deliberately do not include any library for AWS requests, in order to
      - Keep dependencies minimal: this is complex enough
      - Never be limited by the library not supporting
        something, while AWS does. Some Fargate-related things are quite new.
      - Be sure we're not blocking the event loop on the hub